### PR TITLE
Add CONTRIBUTING.md with labeling guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,89 @@
+# Contributing
+
+Thanks for contributing to **quiz-cli** 🎉  
+This project uses a simple labeling system to keep issues organized and easy to understand.
+
+
+## 🏷️ Labeling Rules
+
+### 1. Type (required)
+Each issue must have **exactly ONE** type label:
+
+- `type:bug` – something is broken  
+- `type:feature` – new functionality  
+- `type:enhancement` – improvement of existing feature  
+- `type:refactor` – code cleanup, no behavior change  
+- `type:docs` – documentation  
+- `type:chore` – maintenance, CI/CD, dependencies  
+- `type:test` – tests  
+
+### 2. Optional Labels
+
+Use these when helpful (don’t overthink it):
+
+**Priority**
+- `priority:critical`
+- `priority:high`
+- `priority:medium`
+- `priority:low`
+
+**Difficulty**
+- `difficulty:beginner`
+- `difficulty:intermediate`
+- `difficulty:advanced`
+
+**Area**
+- `area:server`
+- `area:client`
+- `area:admin`
+- `area:common`
+- `area:tests`
+- `area:infrastructure`
+
+### 3. Status (workflow)
+
+These change over time:
+
+- `status:ready` – ready to start  
+- `status:in-progress` – being worked on  
+- `status:review-needed` – PR open / needs review  
+- `status:blocked` – cannot continue  
+- `status:duplicate` – duplicate issue  
+- `status:wontfix` – will not be implemented  
+
+### 4. Community Labels
+
+- `good-first-issue` – great for beginners  
+- `help-wanted` – open for contributors  
+- `discussion` – needs clarification  
+- `security` – security-related  
+
+
+## ✅ Examples
+
+**Bug in backend**
+```
+type:bug
+priority:high
+area:server
+status:ready
+```
+
+**Beginner-friendly task**
+
+```
+type:enhancement
+difficulty:beginner
+good-first-issue
+status:ready
+```
+
+
+## 🧠 Keep It Simple
+
+- Always use **one `type:*` label**
+- Use other labels only if they add value
+- Don’t worry about being perfect
+
+If you’re unsure → just ask 🙂
+


### PR DESCRIPTION
## Summary
Adds a `CONTRIBUTING.md` file with clear guidelines for the labeling system, including usage examples.

Closes quiz-cli/.github#1

## Status
- changes requested
